### PR TITLE
Added 'stringification' to Code and PendingEmail objects.

### DIFF
--- a/db.py
+++ b/db.py
@@ -98,6 +98,9 @@ class CodePivot(BaseModel):
 
 	@classmethod
 	def upsert(subclass, **kwargs):
+		code = kwargs.pop('code', None)
+		if code is not None:
+			kwargs['code'] = str(code)
 		return subclass.insert(kwargs).on_conflict_replace().execute()
 
 class PendingEmail(CodePivot):

--- a/db.py
+++ b/db.py
@@ -44,6 +44,10 @@ class Code(BaseModel):
 		return self.code + other
 	def __radd__(self, other):
 		return other + self.code
+	def __eq__(self, other):
+		if isinstance(other, str):
+			return self.code == other
+		return super(Code, self).__eq__(other)
 
 	def get_by_code(code, include_used=False):
 		query = Code.select().where(Code.code == str(code))

--- a/db.py
+++ b/db.py
@@ -37,8 +37,16 @@ class Code(BaseModel):
 	created_at = DateTimeField(default=datetime.now())
 	used_at    = DateTimeField(null=True)
 
+	# This is all for automatic conversion to strings.
+	def __str__(self):
+		return self.code
+	def __add__(self, other):
+		return self.code + other
+	def __radd__(self, other):
+		return other + self.code
+
 	def get_by_code(code, include_used=False):
-		query = Code.select().where(Code.code == code)
+		query = Code.select().where(Code.code == str(code))
 		if not include_used:
 			query = query.where(Code.used_at.is_null())
 		try:
@@ -48,7 +56,7 @@ class Code(BaseModel):
 
 	def use_code(code):
 		'''Sets a code's used_at field, effectively marking it as used.'''
-		Code.update(used_at=datetime.now()).where(Code.code == code).execute()
+		Code.update(used_at=datetime.now()).where(Code.code == str(code)).execute()
 
 	def cull_old_codes():
 		'''Deletes all old, unused codes.'''
@@ -93,6 +101,14 @@ class CodePivot(BaseModel):
 
 class PendingEmail(CodePivot):
 	email = TextField(null=False)
+
+	# This is all for automatic conversion to strings.
+	def __str__(self):
+		return self.email
+	def __add__(self, other):
+		return self.email + other
+	def __radd__(self, other):
+		return other + self.email
 
 class LoginCode(CodePivot):
 	pass

--- a/db.py
+++ b/db.py
@@ -106,14 +106,6 @@ class CodePivot(BaseModel):
 class PendingEmail(CodePivot):
 	email = TextField(null=False)
 
-	# This is all for automatic conversion to strings.
-	def __str__(self):
-		return self.email
-	def __add__(self, other):
-		return self.email + other
-	def __radd__(self, other):
-		return other + self.email
-
 class LoginCode(CodePivot):
 	pass
 

--- a/db.py
+++ b/db.py
@@ -88,7 +88,7 @@ class CodePivot(BaseModel):
 	@classmethod
 	def get_by_code(subclass, code):
 		try:
-			return subclass.select().where(subclass.code == code).get()
+			return subclass.select().where(subclass.code == str(code)).get()
 		except DoesNotExist:
 			return None
 

--- a/db.py
+++ b/db.py
@@ -94,9 +94,6 @@ class CodePivot(BaseModel):
 
 	@classmethod
 	def upsert(subclass, **kwargs):
-		# FIXME temporary sanity-preserving patch until we get to issue #64.
-		if not isinstance(kwargs.get('code', None), str):
-			raise Exception('Need a code string, not an object')
 		return subclass.insert(kwargs).on_conflict_replace().execute()
 
 class PendingEmail(CodePivot):

--- a/server.py
+++ b/server.py
@@ -233,7 +233,7 @@ def addEmail():
 	PendingEmail.upsert(code=code_str, user=user, email=email)
 
 	# TODO we're hard coding this link for now
-	link = 'https://funbox.com.ru:20100/update/email/confirm/' + code.code
+	link = 'https://funbox.com.ru:20100/update/email/confirm/' + code
 	util.sendEmail(email, 'Funbox Email Verification',
 		'Hello from funbox! Use this link to verify your email: ' + link)
 

--- a/server.py
+++ b/server.py
@@ -230,7 +230,7 @@ def addEmail():
 	# Create an email verify code
 	code_str = util.makeUniqueCode(CODE_SIZE)
 	code = Code.get_by_code(code_str)
-	PendingEmail.upsert(code=code_str, user=user, email=email)
+	PendingEmail.upsert(code=code, user=user, email=email)
 
 	# TODO we're hard coding this link for now
 	link = 'https://funbox.com.ru:20100/update/email/confirm/' + code
@@ -240,13 +240,13 @@ def addEmail():
 	return ok()
 
 
-@app.route('/update/email/confirm/<code_str>', methods=['GET'])
-def confirmEmail(code_str):
+@app.route('/update/email/confirm/<code>', methods=['GET'])
+def confirmEmail(code):
 	global CODE_VALIDATOR
-	if CODE_VALIDATOR.match(code_str) is None:
+	if CODE_VALIDATOR.match(code) is None:
 		return forbidden()
 
-	pending = PendingEmail.get_by_code(code_str)
+	pending = PendingEmail.get_by_code(code)
 	if pending is None:
 		return forbidden()
 
@@ -257,7 +257,7 @@ def confirmEmail(code_str):
 
 	user.email = pending.email
 	user.save()
-	Code.use_code(code_str)
+	Code.use_code(code)
 	pending.delete()
 
 	return ok()

--- a/test/db_test.py
+++ b/test/db_test.py
@@ -421,7 +421,7 @@ def databaseTests():
 			assert_that(str(code), equal_to(code.code))
 
 		@it('Handles string concat')
-		def strConv():
+		def strConcat():
 			code = Code.get_by_code(test_code1)
 
 			prefix = "somestuff"

--- a/test/db_test.py
+++ b/test/db_test.py
@@ -198,7 +198,7 @@ def databaseTests():
 			Code.create(code=test_code2)
 
 			code = Code.get_by_code(test_code1)
-			assert_that(code.code, equal_to(test_code1))
+			assert_that(code, equal_to(test_code1))
 			assert_that(code.used_at, none())
 			assertDateNearNow(code.created_at)
 
@@ -381,18 +381,18 @@ def databaseTests():
 			PendingEmail.create(code=added_code, user=test_user, email='aaa')
 			pending = PendingEmail.get_by_code(added_code)
 			assert_that(pending, not_none())
-			assert_that(pending.code.code, equal_to(added_code.code))
+			assert_that(pending.code, equal_to(added_code))
 
 		@it('Get by code LoginCode')
 		def getByCodeLogin():
 			LoginCode.create(code=added_code, user=test_user)
 			login = LoginCode.get_by_code(added_code)
 			assert_that(login, not_none())
-			assert_that(login.code.code, equal_to(added_code.code))
+			assert_that(login.code, equal_to(added_code))
 
 		@it('Upsert PendingEmail')
 		def upsertPending():
-			PendingEmail.create(code=added_code.code, user=test_user, email='aaa')
+			PendingEmail.create(code=added_code, user=test_user, email='aaa')
 			PendingEmail.upsert(code=added_code.code, user=test_user, email='bbb')
 			updated = PendingEmail.get_by_code(added_code)
 			assert_that(updated.email, equal_to('bbb'))
@@ -401,7 +401,7 @@ def databaseTests():
 		def upsertLogin():
 			LoginCode.upsert(code=added_code.code, user=test_user)
 			added = LoginCode.get_by_code(added_code)
-			assert_that(added.code.code, equal_to(added_code.code))
+			assert_that(added.code, equal_to(added_code))
 
 		@it('None returned for non-existing code')
 		def noneCode():
@@ -437,7 +437,7 @@ def databaseTests():
 			assert_that(Code.get_by_code(test_code1), equal_to(test_code1))
 
 		@it('Does not give false positive when comparing two different Code objects')
-		def strCodeCmp():
+		def codeCmp():
 			code1 = Code.get_by_code(test_code1)
 			code2 = Code.get_by_code(test_code2)
 
@@ -447,6 +447,9 @@ def databaseTests():
 			#Two codes with the same code (which I'm sure violates a constraint)
 			#should still not equal if any properties other than the code
 			#don't equate.
+			#
+			#If these equate there is something fundamentally wrong with the
+			# __eq__ override.
 			code2.code = code1.code
 			code2.used_at = datetime.now
 			assert_that(code1, not_(equal_to(code2)))

--- a/test/db_test.py
+++ b/test/db_test.py
@@ -378,14 +378,14 @@ def databaseTests():
 		@it('Get by code PendingEmail')
 		def getByCodePendingEmail():
 			PendingEmail.create(code=added_code, user=test_user, email='aaa')
-			pending = PendingEmail.get_by_code(added_code.code)
+			pending = PendingEmail.get_by_code(added_code)
 			assert_that(pending, not_none())
 			assert_that(pending.code.code, equal_to(added_code.code))
 
 		@it('Get by code LoginCode')
 		def getByCodeLogin():
 			LoginCode.create(code=added_code, user=test_user)
-			login = LoginCode.get_by_code(added_code.code)
+			login = LoginCode.get_by_code(added_code)
 			assert_that(login, not_none())
 			assert_that(login.code.code, equal_to(added_code.code))
 
@@ -393,13 +393,13 @@ def databaseTests():
 		def upsertPending():
 			PendingEmail.create(code=added_code.code, user=test_user, email='aaa')
 			PendingEmail.upsert(code=added_code.code, user=test_user, email='bbb')
-			updated = PendingEmail.get_by_code(added_code.code)
+			updated = PendingEmail.get_by_code(added_code)
 			assert_that(updated.email, equal_to('bbb'))
 
 		@it('Upsert LoginCode')
 		def upsertLogin():
 			LoginCode.upsert(code=added_code.code, user=test_user)
-			added = LoginCode.get_by_code(added_code.code)
+			added = LoginCode.get_by_code(added_code)
 			assert_that(added.code.code, equal_to(added_code.code))
 
 		@it('None returned for non-existing code')

--- a/test/db_test.py
+++ b/test/db_test.py
@@ -393,13 +393,13 @@ def databaseTests():
 		@it('Upsert PendingEmail')
 		def upsertPending():
 			PendingEmail.create(code=added_code, user=test_user, email='aaa')
-			PendingEmail.upsert(code=added_code.code, user=test_user, email='bbb')
+			PendingEmail.upsert(code=added_code, user=test_user, email='bbb')
 			updated = PendingEmail.get_by_code(added_code)
 			assert_that(updated.email, equal_to('bbb'))
 
 		@it('Upsert LoginCode')
 		def upsertLogin():
-			LoginCode.upsert(code=added_code.code, user=test_user)
+			LoginCode.upsert(code=added_code, user=test_user)
 			added = LoginCode.get_by_code(added_code)
 			assert_that(added.code, equal_to(added_code))
 

--- a/test/db_test.py
+++ b/test/db_test.py
@@ -406,3 +406,26 @@ def databaseTests():
 		def noneCode():
 			assert_that(PendingEmail.get_by_code('bad'), none())
 
+	@describe('Code class')
+	def classCode():
+
+		@beforeEach
+		def _beforeEach():
+			testutil.clearDatabase()
+			Code.create(code=test_code1)
+
+		@it('Can convert to a string')
+		def strConv():
+			code = Code.get_by_code(test_code1)
+			assert_that(str(code), equal_to(test_code1))
+			assert_that(str(code), equal_to(code.code))
+
+		@it('Handles string concat')
+		def strConv():
+			code = Code.get_by_code(test_code1)
+
+			prefix = "somestuff"
+
+			assert_that(prefix + code, equal_to(prefix + test_code1))
+			assert_that(code + prefix, equal_to(test_code1 + prefix))
+			assert_that(code + code, equal_to(test_code1 + test_code1))

--- a/test/db_test.py
+++ b/test/db_test.py
@@ -429,3 +429,6 @@ def databaseTests():
 			assert_that(prefix + code, equal_to(prefix + test_code1))
 			assert_that(code + prefix, equal_to(test_code1 + prefix))
 			assert_that(code + code, equal_to(test_code1 + test_code1))
+
+	#TODO: In the future when PendingEmail is ready for tests,
+	#copy the Code Class test patterns into PendingEmail tests.

--- a/test/db_test.py
+++ b/test/db_test.py
@@ -4,7 +4,6 @@ import scrypt
 from time import sleep
 from datetime import datetime, timedelta
 from peewee import IntegrityError
-from copy import copy
 
 import testutil
 from db import User, Code, PendingEmail, LoginCode

--- a/test/server_test.py
+++ b/test/server_test.py
@@ -133,7 +133,7 @@ def serverTests():
 			assert_that(Code.get_by_code(code), not_none())
 			login_code = LoginCode.get_by_code(code)
 			assert_that(login_code, not_none())
-			assert_that(login_code.code.code, equal_to(code))
+			assert_that(login_code.code, equal_to(code))
 
 		@it('Missing CSRF token')
 		def missingCSRFToken():
@@ -263,7 +263,7 @@ def serverTests():
 			assert_that(Code.get_by_code(code), not_none())
 			login_code = LoginCode.get_by_code(code)
 			assert_that(login_code, not_none())
-			assert_that(login_code.code.code, equal_to(code))
+			assert_that(login_code.code, equal_to(code))
 
 		@it('User does not exist')
 		def userDoesNotExist():
@@ -383,7 +383,7 @@ def serverTests():
 				code = session['login']
 			login_code = LoginCode.get_by_user(test_user)
 			assert_that(login_code, not_none())
-			assert_that(login_code.code.code, equal_to(code))
+			assert_that(login_code.code, equal_to(code))
 			assert_that(Code.get_by_code(code).used_at, none())
 
 			# Do logout
@@ -655,7 +655,7 @@ def serverTests():
 			pending = PendingEmail.get_by_code(code)
 			assert_that(pending, not_none())
 			assert_that(pending.email, equal_to(email))
-			assert_that(pending.code.code, equal_to(code))
+			assert_that(pending.code, equal_to(code))
 
 		@it('Overwriting PendingEmail')
 		@patch('util.sendEmail')


### PR DESCRIPTION
This makes Code and PendingEmail objects automatically convert to strings only containing the primary key when used in print(), str() statements, and in string concatenation situations.

This should be a solution that closes #64 

When you have a function that either expects a code string or a code object, using str() on the input will always get you the string version.