### PR TITLE
Better security

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 fbusers.db
 todo.txt
 *.key
+*.pem

--- a/config.yaml
+++ b/config.yaml
@@ -20,9 +20,14 @@ log:
   keep: 10
   #format: '' # Not sure if this is even reasonable
 
-# Not implemented since we're proxying through Apache.
-# It might be fun to implement this in the future \_('_')_/
+# Currently just set for testing with https
+# TODO might not need this with Apache
+# NOTE In dev, toggling https when the browser has an active cookie can
+# cause the server to fail to give the browser a new cookie. The work-around is
+# to toggle https back to what it was before, reload, then clear the cookie.
+# Also, https can just be really frickin slow, for some reason.
+# Finally, enabling this will make *all* the server tests fail.
 https:
   enabled: false
-  cert_file: null
-  key_file: null
+  cert_file: 'cert.pem'
+  key_file: 'key.pem'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 flask
 Flask-WTF
 flask-limiter
+flask-talisman
 peewee
 pysqlite3
 pyyaml

--- a/server.py
+++ b/server.py
@@ -36,9 +36,9 @@ limiter = Limiter(app, key_func=get_remote_address)
 login_limit = limiter.shared_limit(config['rate_login'], scope='login')
 
 Talisman(app,
-	force_https=False, # Apache should handle https for us, in theory
+	force_https=config['https']['enabled'],
 	session_cookie_http_only=True,
-	session_cookie_secure=False, # TODO can't enable this without https in dev
+	session_cookie_secure=config['https']['enabled'],
 	strict_transport_security=True
 )
 
@@ -334,5 +334,14 @@ def forbidden():
 
 
 if __name__ == '__main__':
-	app.run(host=config['host'], port=config['port'], debug=config['debug'])
+	context=None
+	if config['https']['enabled']:
+		context = (config['https']['cert_file'], config['https']['key_file'])
+
+	app.run(
+		host=config['host'],
+		port=config['port'],
+		debug=config['debug'],
+		ssl_context=context
+	)
 

--- a/server.py
+++ b/server.py
@@ -9,7 +9,7 @@ from flask import Flask, jsonify, redirect, render_template, request, session
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_talisman import Talisman
-from flask_wtf.csrf import CSRFError, CSRFProtect,
+from flask_wtf.csrf import CSRFError, CSRFProtect
 from playhouse.shortcuts import model_to_dict
 import scrypt
 

--- a/server.py
+++ b/server.py
@@ -8,6 +8,7 @@ import yaml
 from flask import Flask, jsonify, redirect, render_template, request, session
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
+from flask_talisman import Talisman
 from flask_wtf.csrf import CSRFError, CSRFProtect,
 from playhouse.shortcuts import model_to_dict
 import scrypt
@@ -34,6 +35,12 @@ app.config['WTF_CSRF_CHECK_DEFAULT'] = False
 limiter = Limiter(app, key_func=get_remote_address)
 login_limit = limiter.shared_limit(config['rate_login'], scope='login')
 
+Talisman(app,
+	force_https=False, # Apache should handle https for us, in theory
+	session_cookie_http_only=True,
+	session_cookie_secure=False, # TODO can't enable this without https in dev
+	strict_transport_security=True
+)
 
 @app.errorhandler(404)
 @app.errorhandler(405)

--- a/setup.sh
+++ b/setup.sh
@@ -13,6 +13,8 @@ else
     then
         echo "Installing all the requirements for the tests."
         pip3 install -r test-requirements.txt
+        echo "Creating test SSL keys"
+        openssl req -x509 -newkey rsa:4096 -nodes -out cert.pem -keyout key.pem -days 365
     else
         echo "Add the command line option --test if you want to install the requirements for the tests."
     fi


### PR DESCRIPTION
Handles #71 and sort of handles #9. We still haven't really looked into proxying through Apache for https, and it may be that we just don't need to enable it on Flask's side at all. Regardless, this adds the ability to have https in development.